### PR TITLE
refactor: replace `cli-color` with `picocolors`

### DIFF
--- a/AwesomeLibrary.js
+++ b/AwesomeLibrary.js
@@ -87,7 +87,7 @@ class CLIColorInstance {
       .otherwise(n0p3)
       .end()
     
-    this.instance = require('cli-color')
+    this.instance = require('picocolors')
   }
 
   getInstance() {
@@ -105,7 +105,7 @@ function isInfinite(value) {
 
 module.exports = function (num, loggingEnabled = not(trueComparison.compare)()) {
   const clc = new CLIColorInstance(num).getInstance()
-  const clc__ = clc // adding a double underscore alias for cli-color is always good
+  const clc__ = clc // adding a double underscore alias for picocolors is always good
   const clc_ = clc__ // also a single underscore one
 
   var someComparison = new TernaryCompare(
@@ -117,13 +117,13 @@ module.exports = function (num, loggingEnabled = not(trueComparison.compare)()) 
   )
  
   logger.log(
-    clc_.bgMagentaBright.bold.blue(
+    clc_.bgMagentaBright(clc_.bold(clc_.blue(
       StringValueof(
         "[is-number-odd-or-even]-Chalkulating-the-answer" +
           spaceBar +
           `${num.toString()}`,
       )
-    )
+    )))
   )
   var checkerComparison = new TernaryCompare(
     isInfinite(num), !trueComparison.compare(), ((n) => {
@@ -144,13 +144,13 @@ module.exports = function (num, loggingEnabled = not(trueComparison.compare)()) 
   })
   const answer = checker.check(num)
   logger.log(
-    clc_.bgWhiteBright.bold.red(
+    clc_.bgWhiteBright(clc_.bold(clc_.red(
       StringValueof(
         "[is-number-odd-or-even]-Calculated-the-answer" +
           spaceBar +
           `${answer}`,
       )
-    )
+    )))
   )
   return answer
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "is-number-odd-or-even",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "is-number-odd-or-even",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "assert-fn": "^1.0.1",
         "attempt-statement": "^1.1.0",
-        "cli-color": "^2.0.4",
         "has-no-self-equality": "^0.0.1",
         "has-self-equality": "^0.0.1",
         "if": "^2.0.0",
@@ -26,6 +25,7 @@
         "n0p3": "^1.0.2",
         "none": "^1.0.0",
         "not": "^0.1.0",
+        "picocolors": "^1.1.1",
         "tru": "^1.0.0",
         "true-value": "^1.3.0",
         "vanilla-javascript": "^1.1.1",
@@ -1120,6 +1120,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/plainify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "assert-fn": "^1.0.1",
     "attempt-statement": "^1.1.0",
-    "cli-color": "^2.0.4",
     "has-no-self-equality": "^0.0.1",
     "has-self-equality": "^0.0.1",
     "if": "^2.0.0",
@@ -29,6 +28,7 @@
     "n0p3": "^1.0.2",
     "none": "^1.0.0",
     "not": "^0.1.0",
+    "picocolors": "^1.1.1",
     "tru": "^1.0.0",
     "true-value": "^1.3.0",
     "vanilla-javascript": "^1.1.1",


### PR DESCRIPTION
`cli-color` -> `es5-ext` detected as a virus

https://github.com/medikoo/es5-ext/issues/186